### PR TITLE
Added plugin which supports multiple displays on a slave

### DIFF
--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/plugin/ParallelXvfbBuildPlugin.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/plugin/ParallelXvfbBuildPlugin.groovy
@@ -1,0 +1,25 @@
+package uk.gov.hmrc.jenkinsjobbuilders.domain.plugin
+
+final class ParallelXvfbBuildPlugin implements Plugin {
+
+    private ParallelXvfbBuildPlugin() {}
+
+    Closure toDsl() {
+        return {
+            it / 'buildWrappers' / 'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper' {
+                'switch'('on')
+                'installationName'('default')
+                'screen'('1920x1080x24')
+                'displayNameOffset'('1')
+                'debug'('true')
+                'timeout'('0')
+                'parallelBuild'('true')
+                'shutdownWithBuild'('true')
+            }
+        }
+    }
+
+    static ParallelXvfbBuildPlugin xvfbBuildPlugin() {
+        new ParallelXvfbBuildPlugin()
+    }
+}

--- a/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/plugin/ParallelXvfbBuildPluginSpec.groovy
+++ b/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/plugin/ParallelXvfbBuildPluginSpec.groovy
@@ -1,0 +1,34 @@
+package uk.gov.hmrc.jenkinsjobbuilders.domain.plugin
+
+import javaposse.jobdsl.dsl.Job
+import spock.lang.Specification
+import uk.gov.hmrc.jenkinsjobbuilders.domain.JobBuilder
+import uk.gov.hmrc.jenkinsjobbuilders.domain.JobParents
+
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.plugin.ParallelXvfbBuildPlugin.xvfbBuildPlugin
+
+@Mixin(JobParents)
+class ParallelXvfbBuildPluginSpec extends Specification {
+
+    void 'test parallel Xvfb plugin'() {
+        given:
+        JobBuilder jobBuilder = new JobBuilder('test-job', 'test-job-description').
+                                               withPlugins(xvfbBuildPlugin())
+
+        when:
+        Job job = jobBuilder.build(jobParent())
+
+        then:
+        job.name == 'test-job'
+
+        with(job.node) {
+            name() == 'project'
+            description.text() == 'test-job-description'
+            buildWrappers.'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper'.switch.text() == 'on'
+            buildWrappers.'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper'.parallelBuild.text() == 'true'
+            buildWrappers.'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper'.displayName.isEmpty()
+            buildWrappers.'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper'.displayNameOffset.text() == '1'
+            buildWrappers.'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper'.screen.text() == '1920x1080x24'
+        }
+    }
+}

--- a/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/plugin/XvfbBuildPluginSpec.groovy
+++ b/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/plugin/XvfbBuildPluginSpec.groovy
@@ -1,0 +1,35 @@
+package uk.gov.hmrc.jenkinsjobbuilders.domain.plugin
+
+import javaposse.jobdsl.dsl.Job
+import spock.lang.Specification
+import uk.gov.hmrc.jenkinsjobbuilders.domain.JobBuilder
+import uk.gov.hmrc.jenkinsjobbuilders.domain.JobParents
+
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.plugin.XvfbBuildPlugin.xvfbBuildPlugin
+
+@Mixin(JobParents)
+class XvfbBuildPluginSpec extends Specification {
+
+    void 'test non-parallel Xvfb plugin'() {
+        given:
+        JobBuilder jobBuilder = new JobBuilder('test-job', 'test-job-description').
+                                               withPlugins(xvfbBuildPlugin())
+
+        when:
+        Job job = jobBuilder.build(jobParent())
+
+        then:
+        job.name == 'test-job'
+
+        with(job.node) {
+            name() == 'project'
+            description.text() == 'test-job-description'
+            buildWrappers.'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper'.switch.text() == 'on'
+            buildWrappers.'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper'.displayName.text() == '99'
+            buildWrappers.'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper'.parallelBuild.isEmpty()
+            buildWrappers.'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper'.displayNameOffset.text() == '1'
+            buildWrappers.'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper'.screen.text() == '1920x1080x24'
+        }
+    }
+
+}


### PR DESCRIPTION
When running jobs on a Jenkins setup where the slaves run one job at a time, the XvfbBuildPlugin will work with the specified display (99). Where slaves can run multiple jobs in parallel and alternative approach can be adopted where the display is calculated by using the executor as an offset.

See new proposed plugin which is a copy of XvfbBuildPlugin - but doesn't specify a display and configures for parallel running.