### PR TITLE
Only configure the bintray task when it is included in the task execution graph.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ publishing {
     }
 }
 
-bintray {
+onlyFor('bintray') {
     user = credentials('user')
     key = credentials('password')
     publications = ['mavenJava']
@@ -62,3 +62,13 @@ def credentials(String key) {
     credentials.load(file.newDataInputStream())
     credentials.get(key)
 }
+
+def onlyFor(task, config) {
+    gradle.taskGraph.whenReady { graph ->
+        if (graph.hasTask(task)) { 
+            project.configure(project, config)
+        }
+    }
+}
+
+


### PR DESCRIPTION
This makes the project easier for non HMRC users (who won't have the HMRC Bintray credentials file) to get started. Otherwise the build refuses to run due to the absence of this file (which in my case caused IntelliJ to be unable to import the project. 