### PR TITLE
Create and publish sources jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ dependencies {
     testCompile 'org.jenkins-ci:version-number:1.1'
 }
 
+task sourceJar(type: Jar) {
+    from sourceSets.main.allSource
+}
+
 version = '3.12.0'
 group = 'uk.gov.hmrc'
 
@@ -35,6 +39,10 @@ publishing {
     publications {
         mavenJava(MavenPublication) {
             from components.java
+
+            artifact sourceJar {
+                classifier "sources"
+            }
         }
     }
 }


### PR DESCRIPTION
Whilst IntelliJ's decompiled bytecode is pretty good, having the sources jar available would make it  easier to delve in to the code when trying to figure out which part of the library I should be using in my job scripts.
