### PR TITLE
Fix clean workspace post build task for gatling

### DIFF
--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/publisher/CleanWorkspacePostBuildTaskPublisher.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/publisher/CleanWorkspacePostBuildTaskPublisher.groovy
@@ -9,7 +9,7 @@ class CleanWorkspacePostBuildTaskPublisher implements Publisher {
         this.publisher = postBuildTaskPublisher('Started by(.*)', """\
                                                                   |#!/bin/bash
                                                                   |cd \${WORKSPACE}
-                                                                  |find . -maxdepth 1 -not -path . -not -path '*target*' -not -path '*logs*' -type d | xargs rm -rf
+                                                                  |find . -maxdepth 1 -not -path . -not -path '*target*' -not -path '*logs*' -not -path '*results*' -type d | xargs rm -rf
                                                                   |if [ -d target ]; then
                                                                   |  find target -mindepth 2 -not -path '*report*' \\( -type f -o -type d -empty \\) -delete
                                                                   |fi


### PR DESCRIPTION
The [Jenkins gatling plugin](http://gatling.io/docs/2.0.1/extensions/jenkins_plugin.html#how-it-works) requires that simulation results be in a
file with convention ./results/simulation_name/simulation_date.
Previously the clean workspace post build task would delete the results
folder and its children. This is no longer the case.