### PR TITLE
Dc 731 conditional shell step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.iws
 *.iml
 build
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 *.iws
 *.iml
 build
-*.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     testCompile 'org.jenkins-ci:version-number:1.1'
 }
 
-version = '10.5.0'
+version = '10.6.0'
 group = 'uk.gov.hmrc'
 
 publishing {

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/ConditionalShellStep.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/ConditionalShellStep.groovy
@@ -1,0 +1,45 @@
+package uk.gov.hmrc.jenkinsjobbuilders.domain.step
+
+class ConditionalShellStep extends ShellStep {
+    private final StepCondition stepCondition
+
+    private ConditionalShellStep(String command, StepCondition stepCondition) {
+        super(command)
+        this.stepCondition = stepCondition
+    }
+
+    static Step conditionalShellStep(String command, StepCondition condition) {
+        new ConditionalShellStep(command, condition)
+    }
+
+    @Override
+    Closure toDsl() {
+        stepCondition.isNegative() ? negativeCauseCondition() : affermativeCauseCondition()
+    }
+
+    Closure affermativeCauseCondition() {
+        return {
+            conditionalSteps {
+                condition {
+                    cause(stepCondition.getCause(), false)
+                }
+                runner(stepCondition.getBehaviour())
+                shell(command)
+            }
+        }
+    }
+
+    Closure negativeCauseCondition() {
+        return {
+            conditionalSteps {
+                condition {
+                    not {
+                        cause(stepCondition.getCause(), false)
+                    }
+                }
+                runner(stepCondition.getBehaviour())
+                shell(command)
+            }
+        }
+    }
+}

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/ShellStep.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/ShellStep.groovy
@@ -2,9 +2,9 @@ package uk.gov.hmrc.jenkinsjobbuilders.domain.step
 
 
 class ShellStep implements Step {
-    private final String command
+    final String command
 
-    private ShellStep(String command) {
+    ShellStep(String command) {
         this.command = command
     }
 

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/StepCondition.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/StepCondition.groovy
@@ -1,5 +1,7 @@
 package uk.gov.hmrc.jenkinsjobbuilders.domain.step
 
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.EvaluationFailureBehaviour.RUN
+
 class StepCondition {
 
     private boolean negative = false
@@ -10,10 +12,12 @@ class StepCondition {
     }
 
     static StepCondition runCondition() {
-        return new StepCondition()
+        StepCondition stepCondition = new StepCondition()
+        stepCondition.andIfFailure(RUN)
+        return stepCondition
     }
 
-    StepCondition not() {
+    StepCondition isNot() {
         return runCondition().negate()
     }
 
@@ -26,7 +30,7 @@ class StepCondition {
         return runCondition()
     }
 
-    StepCondition whenCausedBy(Cause cause) {
+    StepCondition causedBy(Cause cause) {
         this.cause = cause.getValue()
         this
     }

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/StepCondition.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/StepCondition.groovy
@@ -26,7 +26,7 @@ class StepCondition {
         return runCondition()
     }
 
-    StepCondition when(Cause cause) {
+    StepCondition whenCausedBy(Cause cause) {
         this.cause = cause.getValue()
         this
     }

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/StepCondition.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/StepCondition.groovy
@@ -1,0 +1,79 @@
+package uk.gov.hmrc.jenkinsjobbuilders.domain.step
+
+class StepCondition {
+
+    private boolean negative = false
+    private String cause
+    private String behaviour
+    boolean isSet() {
+        return (cause != null && behaviour != null)
+    }
+
+    static StepCondition runCondition() {
+        return new StepCondition()
+    }
+
+    StepCondition not() {
+        return runCondition().negate()
+    }
+
+    StepCondition negate() {
+        this.negative = !this.negative
+        this
+    }
+
+    static StepCondition noCondition() {
+        return runCondition()
+    }
+
+    StepCondition when(Cause cause) {
+        this.cause = cause.getValue()
+        this
+    }
+
+    StepCondition andIfFailure(Behaviour behaviour) {
+        this.behaviour = behaviour.getValue()
+        this
+    }
+
+    String getCause() {
+        return cause
+    }
+
+    String getBehaviour() {
+        return behaviour
+    }
+
+    boolean isNegative() {
+        return negative
+    }
+
+    enum Behaviour {
+        RUN("Run"), DONT_RUN("DontRun")
+
+        private final String value
+
+        Behaviour(String value) {
+            this.value = value
+        }
+
+        String getValue() {
+            this.value
+        }
+    }
+
+    enum Cause {
+        UPSTREAM_CAUSE("UPSTREAM_CAUSE")
+
+        private final String value
+
+        Cause(String value) {
+            this.value = value
+        }
+
+        String getValue() {
+            this.value
+        }
+    }
+}
+

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/StepCondition.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/StepCondition.groovy
@@ -31,7 +31,7 @@ class StepCondition {
         this
     }
 
-    StepCondition andIfFailure(Behaviour behaviour) {
+    StepCondition andIfFailure(EvaluationFailureBehaviour behaviour) {
         this.behaviour = behaviour.getValue()
         this
     }
@@ -48,12 +48,16 @@ class StepCondition {
         return negative
     }
 
-    enum Behaviour {
-        RUN("Run"), DONT_RUN("DontRun")
+    enum EvaluationFailureBehaviour {
+        RUN("Run"),
+        RUN_UNSTABLE("RunUnstable"),
+        DONT_RUN("DontRun"),
+        FAIL("Fail"),
+        UNSTABLE("Unstable")
 
         private final String value
 
-        Behaviour(String value) {
+        EvaluationFailureBehaviour(String value) {
             this.value = value
         }
 

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/StepCondition.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/StepCondition.groovy
@@ -63,7 +63,17 @@ class StepCondition {
     }
 
     enum Cause {
-        UPSTREAM_CAUSE("UPSTREAM_CAUSE")
+        UPSTREAM_CAUSE("UPSTREAM_CAUSE"),
+        USER_CAUSE("USER_CAUSE"),
+        CLI_CAUSE("CLI_CAUSE"),
+        REMOTE_CAUSE("REMOTE_CAUSE"),
+        SCM_TRIGGER("SCM_CAUSE"),
+        TIMER_TRIGGER("TIMER_CAUSE"),
+        FS_TRIGGER("FS_CAUSE"),
+        URL_TRIGGER("URL_CAUSE"),
+        IVY_TRIGGER("IVY_CAUSE"),
+        SCRIPT_TRIGGER("SCRIPT_CAUSE"),
+        BUILD_RESULT_TRIGGER("BUILDRESULT_CAUSE")
 
         private final String value
 

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/conditional-shell-step.md
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/conditional-shell-step.md
@@ -9,7 +9,7 @@ import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.runCondit
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.Behaviour.DONT_RUN
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.Cause.UPSTREAM_CAUSE
 
-StepCondition condition = runCondition().whenCausedBy(UPSTREAM_CAUSE).andIfFailure(DONT_RUN)
+StepCondition condition = runCondition().causedBy(UPSTREAM_CAUSE).andIfFailure(DONT_RUN)
 ```
 
 a `ConditionalShellStep` will generate a step that will run only if the cause that triggered the job was an upstream job, and if Jenkins cannot determine the cause (in case of failure) as default it will not run the step.
@@ -22,7 +22,8 @@ if(condition.isSet)
     conditionalShellStep("echo 'This job was triggered by an upstream job'", condition)
 ```
 
-A `StepCondition` can also be negated, and a construct is provided:
+A `StepCondition` can also be negated (if the evaluation exception behaviour is not specified, the `RUN` will be applied), and a construct is provided:
 ```groovy
-StepCondition condition = runCondition().not().whenCausedBy(UPSTREAM_CAUSE).andIfFailure(DONT_RUN)
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.Cause.TIMER_TRIGGER
+StepCondition condition = runCondition().isNot().causedBy(TIMER_TRIGGER)
 ```

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/conditional-shell-step.md
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/conditional-shell-step.md
@@ -1,0 +1,28 @@
+###How to use a ConditionalShellStep
+ 
+ Given a `StepCondition`, a `shellStep` can be run or not depending on the cause that triggered the job.
+ If a `StepCondition` is defined as:
+ 
+ ```groovy
+import uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.runCondition
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.Behaviour.DONT_RUN
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.Cause.UPSTREAM_CAUSE
+
+StepCondition condition = runCondition().whenCausedBy(UPSTREAM_CAUSE).andIfFailure(DONT_RUN)
+```
+
+a `ConditionalShellStep` will generate a step that will run only if the cause that triggered the job was an upstream job, and if Jenkins cannot determine the cause (in case of failure) as default it will not run the step.
+For example, given the previous condition:
+
+```groovy
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.ConditionalShellStep.conditionalShellStep
+
+if(condition.isSet)
+    conditionalShellStep("echo 'This job was triggered by an upstream job'", condition)
+```
+
+A `StepCondition` can also be negated, and a construct is provided:
+```groovy
+StepCondition condition = runCondition().not().whenCausedBy(UPSTREAM_CAUSE).andIfFailure(DONT_RUN)
+```

--- a/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/ConditionalStepSpec.groovy
+++ b/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/ConditionalStepSpec.groovy
@@ -16,7 +16,7 @@ class ConditionalStepSpec extends Specification {
     void 'test XML output'() {
         given:
         JobBuilder jobBuilder = new JobBuilder('test-job', 'test-job-description')
-            .withSteps(conditionalShellStep('hello-world', runCondition().not().whenCausedBy(UPSTREAM_CAUSE).andIfFailure(DONT_RUN)))
+            .withSteps(conditionalShellStep('hello-world', runCondition().isNot().causedBy(UPSTREAM_CAUSE).andIfFailure(DONT_RUN)))
 
         when:
         Job job = jobBuilder.build(jobParent())

--- a/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/ConditionalStepSpec.groovy
+++ b/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/ConditionalStepSpec.groovy
@@ -16,7 +16,7 @@ class ConditionalStepSpec extends Specification {
     void 'test XML output'() {
         given:
         JobBuilder jobBuilder = new JobBuilder('test-job', 'test-job-description')
-            .withSteps(conditionalShellStep('hello-world', runCondition().not().when(UPSTREAM_CAUSE).andIfFailure(DONT_RUN)))
+            .withSteps(conditionalShellStep('hello-world', runCondition().not().whenCausedBy(UPSTREAM_CAUSE).andIfFailure(DONT_RUN)))
 
         when:
         Job job = jobBuilder.build(jobParent())

--- a/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/ConditionalStepSpec.groovy
+++ b/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/ConditionalStepSpec.groovy
@@ -6,7 +6,7 @@ import uk.gov.hmrc.jenkinsjobbuilders.domain.JobParents
 import uk.gov.hmrc.jenkinsjobbuilders.domain.builder.JobBuilder
 
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.ConditionalShellStep.conditionalShellStep
-import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.Behaviour.DONT_RUN
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.EvaluationFailureBehaviour.DONT_RUN
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.Cause.UPSTREAM_CAUSE
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.runCondition
 

--- a/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/ConditionalStepSpec.groovy
+++ b/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/ConditionalStepSpec.groovy
@@ -1,0 +1,31 @@
+package uk.gov.hmrc.jenkinsjobbuilders.domain.step
+
+import javaposse.jobdsl.dsl.Job
+import spock.lang.Specification
+import uk.gov.hmrc.jenkinsjobbuilders.domain.JobParents
+import uk.gov.hmrc.jenkinsjobbuilders.domain.builder.JobBuilder
+
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.ConditionalShellStep.conditionalShellStep
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.Behaviour.DONT_RUN
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.Cause.UPSTREAM_CAUSE
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.runCondition
+
+@Mixin(JobParents)
+class ConditionalStepSpec extends Specification {
+
+    void 'test XML output'() {
+        given:
+        JobBuilder jobBuilder = new JobBuilder('test-job', 'test-job-description')
+            .withSteps(conditionalShellStep('hello-world', runCondition().not().when(UPSTREAM_CAUSE).andIfFailure(DONT_RUN)))
+
+        when:
+        Job job = jobBuilder.build(jobParent())
+
+        then:
+        with(job.node) {
+            println(builders.'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder')
+            builders.'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder'.buildStep.command.text().contains('hello-world')
+            builders.'org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder'.condition.condition.buildCause.text().contains('UPSTREAM_CAUSE')
+        }
+    }
+}


### PR DESCRIPTION
In order to exclude some build steps under some specific conditions, the concept of a "ConditionalShellStep" has been introduced within the codebase.

Specifically, the need to skip publishing and deploying artefacts was needed when a job was triggered by an upstream job, or just by a timer (in which case build/test/itTest need to run, but no artefacts generation is required).

An example of the output that this change will produce (has been locally tested on Jenkins ver. 1.565.2)
![image](https://cloud.githubusercontent.com/assets/2122700/21889771/7e0d02c6-d8c2-11e6-9bae-0a4dd37ef590.png)

**Example on how to use a ConditionalShellStep**
 
 Given a `StepCondition`, a `shellStep` can be run or not depending on the cause that triggered the job.
 If a `StepCondition` is defined as:
 
 ```groovy
import uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition
import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.runCondition
import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.Behaviour.DONT_RUN
import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.Cause.UPSTREAM_CAUSE

StepCondition condition = runCondition().causedBy(UPSTREAM_CAUSE).andIfFailure(DONT_RUN)
```

a `ConditionalShellStep` will generate a step that will run only if the cause that triggered the job was an upstream job, and if Jenkins cannot determine the cause (in case of failure) as default it will not run the step.
For example, given the previous condition:

```groovy
import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.ConditionalShellStep.conditionalShellStep

if(condition.isSet)
    conditionalShellStep("echo 'This job was triggered by an upstream job'", condition)
```

A `StepCondition` can also be negated (if the evaluation exception behaviour is not specified, the `RUN` will be applied), and a construct is provided:
```groovy
import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.StepCondition.Cause.TIMER_TRIGGER
StepCondition condition = runCondition().isNot().causedBy(TIMER_TRIGGER)
```