### PR TITLE
[PLATOPS-1140] moving the wrappers to the end of jobs' creation

### DIFF
--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/builder/JobBuilder.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/builder/JobBuilder.groovy
@@ -175,10 +175,6 @@ final class JobBuilder implements Builder<Job> {
                 triggers(it.toDsl())
             }
 
-            this.wrappers.each {
-                wrappers(it.toDsl())
-            }
-
             this.steps.each {
                 steps(it.toDsl())
             }
@@ -195,6 +191,9 @@ final class JobBuilder implements Builder<Job> {
             }
             if (this.throttle != null) {
                 throttleConcurrentBuilds(this.throttle.toDsl())
+            }
+            this.wrappers.each {
+                wrappers(it.toDsl())
             }
         }
     }


### PR DESCRIPTION
There is a defect in our version of Jenkins that causes the secret params not work if they are added in the middle of the configuration. This change is to try and test that generating wrappers is going to work as a workaround