### PR TITLE
PBD-1838 Allow "Honor refspec on initial clone" to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The [open HMRC Jenkins jobs](https://github.com/hmrc/jenkins-jobs) are one examp
 
 ## Release Notes
 
+* 11.30.0 (25/10/2019) - Add support for honoring the refspec in the initial git fetch, and parameterise whether tags are pulled or not 
 * 11.29.0 (01/10/2019) - Add support for [AWS CodeBuild with Jenkins plugin](https://wiki.jenkins.io/display/JENKINS/AWS+CodeBuild+Plugin)
 * 11.27.0 (15/04/2019) - Fix name bug in BuildMonitorViewBuilder.
 * 11.26.0 (02/04/2019) - Implement a conjoined username/password credentials binding.

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/scm/GitHubScm.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/scm/GitHubScm.groovy
@@ -9,8 +9,10 @@ final class GitHubScm implements Scm {
     private final String credentials
     private final String name
     private final int depth
+    private final boolean honorRefspec
+    private final boolean pullTags
 
-    private GitHubScm(String host, String repository, String branch, String protocol, String refspec, String credentials, String name, int depth) {
+    private GitHubScm(String host, String repository, String branch, String protocol, String refspec, String credentials, String name, int depth, boolean honorRefspec, boolean pullTags) {
         this.branch = branch
         this.host = host
         this.protocol = protocol
@@ -19,14 +21,16 @@ final class GitHubScm implements Scm {
         this.credentials = credentials
         this.name = name
         this.depth = depth
+        this.honorRefspec = honorRefspec
+        this.pullTags = pullTags
     }
 
     static GitHubScm gitHubScm(String host, String repository, String branch, String protocol) {
         gitHubScm(host, repository, branch, protocol, null, null, null)
     }
 
-    static GitHubScm gitHubScm(String host, String repository, String branch, String protocol, String refspec, String credentials, String name = null, int depth = 0) {
-        new GitHubScm(host, repository, branch, protocol, refspec, credentials, name, depth)
+    static GitHubScm gitHubScm(String host, String repository, String branch, String protocol, String refspec, String credentials, String name = null, int depth = 0, boolean honorRefspec = false, boolean pullTags = true) {
+        new GitHubScm(host, repository, branch, protocol, refspec, credentials, name, depth, honorRefspec, pullTags)
     }
 
     @Override
@@ -44,13 +48,14 @@ final class GitHubScm implements Scm {
                     if (this.name != null) {
                         name(this.name)
                     }
-                }
-                if (this.depth > 0) {
                     extensions {
                         cloneOptions {
+                            honorRefspec(this.honorRefspec)
+                            noTags(!this.pullTags)
+                            if (this.depth > 0) {
                                 depth(this.depth)
                                 shallow(true)
-                                noTags(true)
+                            }
                         }
                     }
                 }

--- a/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/scm/GitHubComScmSpec.groovy
+++ b/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/scm/GitHubComScmSpec.groovy
@@ -1,0 +1,95 @@
+package uk.gov.hmrc.jenkinsjobbuilders.domain.scm
+
+import javaposse.jobdsl.dsl.Job
+import uk.gov.hmrc.jenkinsjobbuilders.domain.AbstractJobSpec
+import uk.gov.hmrc.jenkinsjobbuilders.domain.builder.JobBuilder
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.scm.GitHubScm.gitHubScm
+
+class GitHubComScmSpec extends AbstractJobSpec {
+    private JobBuilder jobBuilder
+
+    def setup() {
+        jobBuilder = new JobBuilder('test-job', 'test-job-description')
+    }
+
+
+    def "default configuration"() {
+        given:
+        jobBuilder.withScm(gitHubScm("host", "repository", "branch", "ssh", "refspec", "credentials", "name"))
+
+        when:
+        Job job = jobBuilder.build(JOB_PARENT)
+
+        then:
+        with(job.node) {
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.depth.text() == "0"
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.shallow.text() == "false"
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.noTags.text() == "false"
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.honorRefspec.text() == "false"
+        }
+    }
+
+    def "depth and honorRefspec configured"() {
+        given:
+        jobBuilder.withScm(gitHubScm("host", "repository", "branch", "ssh", "refspec", "credentials", "name", 3, true))
+
+        when:
+        Job job = jobBuilder.build(JOB_PARENT)
+
+        then:
+        with(job.node) {
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.depth.text() == "3"
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.shallow
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.noTags.text() == "false"
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.honorRefspec
+        }
+    }
+
+    def "honorRefspec configured"() {
+        given:
+        jobBuilder.withScm(gitHubScm("host", "repository", "branch", "ssh", "refspec", "credentials", "name", 0, true))
+
+        when:
+        Job job = jobBuilder.build(JOB_PARENT)
+
+        then:
+        with(job.node) {
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.depth.text() == "0"
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.shallow.text() == "false"
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.noTags.text() == "false"
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.honorRefspec
+        }
+    }
+
+    def "depth configured"() {
+        given:
+        jobBuilder.withScm(gitHubScm("host", "repository", "branch", "ssh", "refspec", "credentials", "name", 9))
+
+        when:
+        Job job = jobBuilder.build(JOB_PARENT)
+
+        then:
+        with(job.node) {
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.depth.text() == "9"
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.shallow
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.noTags.text() == "false"
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.honorRefspec.text() == "false"
+        }
+    }
+
+    def "pullTags configured"() {
+        given:
+        jobBuilder.withScm(gitHubScm("host", "repository", "branch", "ssh", "refspec", "credentials", "name", 0, false, false))
+
+        when:
+        Job job = jobBuilder.build(JOB_PARENT)
+
+        then:
+        with(job.node) {
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.depth.text() == "0"
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.shallow.text() == "false"
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.noTags
+            scm.extensions.'hudson.plugins.git.extensions.impl.CloneOption'.honorRefspec.text() == "false"
+        }
+    }
+}


### PR DESCRIPTION
- Parameterising `honorRefspec` so that it is false by default, but can be set to true
- `noTags` is no longer set to `true` when `depth` is configured, but can now be configured independently with `pullTags`
- Adding unit tests for `gitHubScm` covering various combinations of `depth`, `honorRefspec` and `pullTags` being configured or not

Co-Authored-by: Lewis Capaldi <55383463+fruiti-lewis@users.noreply.github.com>