### PR TITLE
Make the task "writePluginIndexFile" incremental

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ task resolveTestPlugins(type: Copy) {
 }
 
 task writePluginIndexFile(type: DefaultTask, dependsOn: resolveTestPlugins) {
+    outputs.file "$resolveTestPlugins.destinationDir/index"
     doFirst {
         def baseNames = resolveTestPlugins.source.collect {
             it.name[0..it.name.lastIndexOf('.') - 1]


### PR DESCRIPTION
Hello

This commit makes the task `writePluginIndexFile` incremental by declaring its output file.
Therefore, it removes redundant computation.