### PR TITLE
#NOJIRA Add ability to toggle linklatest on and off

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The [open HMRC Jenkins jobs](https://github.com/hmrc/jenkins-jobs) are one examp
 
 ## Release Notes
 
+* 11.34.0 (13/10/2020) - Allow configuration of alwaysLinkToLastBuild in HtmlReportsPublisher
 * 11.33.0 (05/10/2020) - Modify cucumber reporter to mark build as failed when cucumber report marked as failed
 * 11.32.0 (07/08/2020) - Add support for the PostBuildScript Publisher plugin
 * 11.31.0 (17/01/2020) - Allow to specify the Scala version in the Coverage Report Publisher

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/publisher/HtmlReportsPublisher.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/publisher/HtmlReportsPublisher.groovy
@@ -2,16 +2,18 @@ package uk.gov.hmrc.jenkinsjobbuilders.domain.publisher
 
 
 final class HtmlReportsPublisher implements Publisher {
-    private final Map<String,String> htmlReportDirs
+    private final Map<String, String> htmlReportDirs
     private boolean keep
+    private boolean alwaysLinkLatest
 
-    private HtmlReportsPublisher(Map<String, String> htmlReportDirs, boolean keep = false) {
+    private HtmlReportsPublisher(Map<String, String> htmlReportDirs, boolean keep = false, boolean alwaysLinkLatest = false) {
         this.htmlReportDirs = htmlReportDirs
         this.keep = keep
+        this.alwaysLinkLatest = alwaysLinkLatest
     }
 
-    static HtmlReportsPublisher htmlReportsPublisher(Map<String, String> htmlReportDirs, boolean keep = false) {
-        new HtmlReportsPublisher(htmlReportDirs, keep)
+    static HtmlReportsPublisher htmlReportsPublisher(Map<String, String> htmlReportDirs, boolean keep = false, boolean alwaysLinkLatest = false) {
+        new HtmlReportsPublisher(htmlReportDirs, keep, alwaysLinkLatest)
     }
 
     @Override
@@ -23,6 +25,7 @@ final class HtmlReportsPublisher implements Publisher {
                         reportName(name)
                         allowMissing(true)
                         keepAll(keep)
+                        alwaysLinkToLastBuild(alwaysLinkLatest)
                     }
                 }
             }

--- a/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/publisher/HtmlReportsPublisherSpec.groovy
+++ b/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/publisher/HtmlReportsPublisherSpec.groovy
@@ -1,7 +1,6 @@
 package uk.gov.hmrc.jenkinsjobbuilders.domain.publisher
 
 import javaposse.jobdsl.dsl.Job
-import spock.lang.Specification
 import uk.gov.hmrc.jenkinsjobbuilders.domain.AbstractJobSpec
 import uk.gov.hmrc.jenkinsjobbuilders.domain.builder.JobBuilder
 
@@ -60,6 +59,60 @@ class HtmlReportsPublisherSpec extends AbstractJobSpec {
             publishers.'htmlpublisher.HtmlPublisher'.reportTargets.'htmlpublisher.HtmlPublisherTarget'.reportDir.text() == 'target/fun-browser-test-reports/html-report'
             publishers.'htmlpublisher.HtmlPublisher'.reportTargets.'htmlpublisher.HtmlPublisherTarget'.allowMissing.text() == 'true'
             publishers.'htmlpublisher.HtmlPublisher'.reportTargets.'htmlpublisher.HtmlPublisherTarget'.keepAll.text() == 'false'
+        }
+    }
+
+    void 'With alwaysLinkToLastBuild'() {
+        given:
+        JobBuilder jobBuilder = new JobBuilder('test-job', 'test-job-description').
+                withPublishers(htmlReportsPublisher(['target/fun-browser-test-reports/html-report': 'ScalaTest (fun-browser) Results'], false, true))
+
+        when:
+        Job job = jobBuilder.build(JOB_PARENT)
+
+        then:
+        with(job.node) {
+
+            publishers.'htmlpublisher.HtmlPublisher'.reportTargets.'htmlpublisher.HtmlPublisherTarget'.reportName.text() == 'ScalaTest (fun-browser) Results'
+            publishers.'htmlpublisher.HtmlPublisher'.reportTargets.'htmlpublisher.HtmlPublisherTarget'.reportDir.text() == 'target/fun-browser-test-reports/html-report'
+            publishers.'htmlpublisher.HtmlPublisher'.reportTargets.'htmlpublisher.HtmlPublisherTarget'.allowMissing.text() == 'true'
+            publishers.'htmlpublisher.HtmlPublisher'.reportTargets.'htmlpublisher.HtmlPublisherTarget'.alwaysLinkToLastBuild.text() == 'true'
+        }
+    }
+
+    void 'Without alwaysLinkToLastBuild (default)'() {
+        given:
+        JobBuilder jobBuilder = new JobBuilder('test-job', 'test-job-description').
+                withPublishers(htmlReportsPublisher(['target/fun-browser-test-reports/html-report': 'ScalaTest (fun-browser) Results']))
+
+        when:
+        Job job = jobBuilder.build(JOB_PARENT)
+
+        then:
+        with(job.node) {
+
+            publishers.'htmlpublisher.HtmlPublisher'.reportTargets.'htmlpublisher.HtmlPublisherTarget'.reportName.text() == 'ScalaTest (fun-browser) Results'
+            publishers.'htmlpublisher.HtmlPublisher'.reportTargets.'htmlpublisher.HtmlPublisherTarget'.reportDir.text() == 'target/fun-browser-test-reports/html-report'
+            publishers.'htmlpublisher.HtmlPublisher'.reportTargets.'htmlpublisher.HtmlPublisherTarget'.allowMissing.text() == 'true'
+            publishers.'htmlpublisher.HtmlPublisher'.reportTargets.'htmlpublisher.HtmlPublisherTarget'.alwaysLinkToLastBuild.text() == 'false'
+        }
+    }
+
+    void 'Without alwaysLinkToLastBuild'() {
+        given:
+        JobBuilder jobBuilder = new JobBuilder('test-job', 'test-job-description').
+                withPublishers(htmlReportsPublisher(['target/fun-browser-test-reports/html-report': 'ScalaTest (fun-browser) Results'], false, false))
+
+        when:
+        Job job = jobBuilder.build(JOB_PARENT)
+
+        then:
+        with(job.node) {
+
+            publishers.'htmlpublisher.HtmlPublisher'.reportTargets.'htmlpublisher.HtmlPublisherTarget'.reportName.text() == 'ScalaTest (fun-browser) Results'
+            publishers.'htmlpublisher.HtmlPublisher'.reportTargets.'htmlpublisher.HtmlPublisherTarget'.reportDir.text() == 'target/fun-browser-test-reports/html-report'
+            publishers.'htmlpublisher.HtmlPublisher'.reportTargets.'htmlpublisher.HtmlPublisherTarget'.allowMissing.text() == 'true'
+            publishers.'htmlpublisher.HtmlPublisher'.reportTargets.'htmlpublisher.HtmlPublisherTarget'.alwaysLinkToLastBuild.text() == 'false'
         }
     }
 }


### PR DESCRIPTION
Update the HtmlReportsPublisher DSL to allow you to configure the "Always link to last build" setting.

This will allow you to set the last failing reports when clicking on the report link from your build screen, rather than just the last successful report.