### PR TITLE
#NOJIRA Add clear publishers functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The [open HMRC Jenkins jobs](https://github.com/hmrc/jenkins-jobs) are one examp
 
 ## Release Notes
 
+* 11.35.0 (14/10/2020) - Add clearPublishers to JobBuilder to let you remove all existing publishers set in default Job Builders
 * 11.34.0 (13/10/2020) - Allow configuration of alwaysLinkToLastBuild in HtmlReportsPublisher
 * 11.33.0 (05/10/2020) - Modify cucumber reporter to mark build as failed when cucumber report marked as failed
 * 11.32.0 (07/08/2020) - Add support for the PostBuildScript Publisher plugin

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/builder/JobBuilder.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/builder/JobBuilder.groovy
@@ -137,6 +137,11 @@ final class JobBuilder implements Builder<Job> {
         this
     }
 
+    JobBuilder clearPublishers() {
+        this.publishers.clear()
+        this
+    }
+
     JobBuilder withConfigures(Configure ... configures) {
         withConfigures(asList(configures))
     }

--- a/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/builder/JobBuilderSpec.groovy
+++ b/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/builder/JobBuilderSpec.groovy
@@ -3,7 +3,6 @@ package uk.gov.hmrc.jenkinsjobbuilders.domain.builder
 import javaposse.jobdsl.dsl.Job
 import uk.gov.hmrc.jenkinsjobbuilders.domain.AbstractJobSpec
 
-
 import static java.util.Arrays.asList
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.authorisation.Permission.permissionSetting
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.parameters.ChoiceParameter.choiceParameter
@@ -14,42 +13,42 @@ import static uk.gov.hmrc.jenkinsjobbuilders.domain.publisher.ClaimBrokenBuildsP
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.publisher.HtmlReportsPublisher.htmlReportsPublisher
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.publisher.JUnitReportsPublisher.jUnitReportsPublisher
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.publisher.JobsTriggerPublisher.jobsTriggerPublisher
-import static uk.gov.hmrc.jenkinsjobbuilders.domain.trigger.BintrayArtifactTrigger.bintrayArtifactTrigger
-import static uk.gov.hmrc.jenkinsjobbuilders.domain.trigger.CronTrigger.cronTrigger
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.scm.GitHubComScm.gitHubComScm
-import static uk.gov.hmrc.jenkinsjobbuilders.domain.trigger.GitHubPushTrigger.gitHubPushTrigger
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.SbtStep.sbtStep
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.step.ShellStep.shellStep
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.trigger.BintrayArtifactTrigger.bintrayArtifactTrigger
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.trigger.CronTrigger.cronTrigger
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.trigger.GitHubPushTrigger.gitHubPushTrigger
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.variable.StringEnvironmentVariable.stringEnvironmentVariable
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.wrapper.ColorizeOutputWrapper.colorizeOutputWrapper
-import static uk.gov.hmrc.jenkinsjobbuilders.domain.wrapper.UserVariablesWrapper.userVariablesWrapper
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.wrapper.NodeJsWrapper.nodeJsWrapper
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.wrapper.PreBuildCleanupWrapper.preBuildCleanUpWrapper
+import static uk.gov.hmrc.jenkinsjobbuilders.domain.wrapper.UserVariablesWrapper.userVariablesWrapper
 
 class JobBuilderSpec extends AbstractJobSpec {
 
     void 'test XML output'() {
         given:
         JobBuilder jobBuilder = new JobBuilder('test-job', 'test-job-description').
-                                               withPermissions(permissionSetting("dev-tools", "hudson.model.Item.Read")).
-                                               withLogRotator(14, 10).
-                                               withScm(gitHubComScm('example/example-repo', 'test-credentials')).
-                                               withTriggers(cronTrigger('test-cron'), gitHubPushTrigger(), bintrayArtifactTrigger("H * * * *", "hmrc", "release-candidates", ["test", "test-frontend"])).
-                                               withSteps(shellStep('test-shell1'), sbtStep("ls test", ['clean test', 'dist publish'], '/tmp')).
-                                               withPreScmSteps(shellStep('echo prescm')).
-                                               withEnvironmentVariables(stringEnvironmentVariable('ENV_KEY', 'ENV_VALUE')).
-                                               withEnvironmentVariablesScriptContent("mkdir -p \${TMP}").
-                                               withEnvironmentVariablesGroovyScript("println \"Hello\"").
-                                               withWrappers(nodeJsWrapper(), colorizeOutputWrapper(), preBuildCleanUpWrapper(), userVariablesWrapper()).
-                                               withLabel('single-executor').
-                                               withParameters(stringParameter('STRING-PARAM', 'STRING-VALUE'), choiceParameter('CHOICE-PARAM', asList('CHOICE-VALUE-1', 'CHOICE-VALUE-2'), 'CHOICE-DESC')).
-                                               withPublishers(claimBrokenBuildsPublisher(),
-                                                              jUnitReportsPublisher('test-junit'),
-                                                              htmlReportsPublisher(['target/test-reports/html-report': 'HTML Report']),
-                                                              artifactsPublisher('test-artifacts'),
-                                                              jobsTriggerPublisher('test-jobs'),
-                                                              buildDescriptionByRegexPublisher('test-regex')).
-                                                withThrottle(['deployment'], 0, 1, false)
+                withPermissions(permissionSetting("dev-tools", "hudson.model.Item.Read")).
+                withLogRotator(14, 10).
+                withScm(gitHubComScm('example/example-repo', 'test-credentials')).
+                withTriggers(cronTrigger('test-cron'), gitHubPushTrigger(), bintrayArtifactTrigger("H * * * *", "hmrc", "release-candidates", ["test", "test-frontend"])).
+                withSteps(shellStep('test-shell1'), sbtStep("ls test", ['clean test', 'dist publish'], '/tmp')).
+                withPreScmSteps(shellStep('echo prescm')).
+                withEnvironmentVariables(stringEnvironmentVariable('ENV_KEY', 'ENV_VALUE')).
+                withEnvironmentVariablesScriptContent("mkdir -p \${TMP}").
+                withEnvironmentVariablesGroovyScript("println \"Hello\"").
+                withWrappers(nodeJsWrapper(), colorizeOutputWrapper(), preBuildCleanUpWrapper(), userVariablesWrapper()).
+                withLabel('single-executor').
+                withParameters(stringParameter('STRING-PARAM', 'STRING-VALUE'), choiceParameter('CHOICE-PARAM', asList('CHOICE-VALUE-1', 'CHOICE-VALUE-2'), 'CHOICE-DESC')).
+                withPublishers(claimBrokenBuildsPublisher(),
+                        jUnitReportsPublisher('test-junit'),
+                        htmlReportsPublisher(['target/test-reports/html-report': 'HTML Report']),
+                        artifactsPublisher('test-artifacts'),
+                        jobsTriggerPublisher('test-jobs'),
+                        buildDescriptionByRegexPublisher('test-regex')).
+                withThrottle(['deployment'], 0, 1, false)
         when:
         Job job = jobBuilder.build(JOB_PARENT)
 
@@ -79,15 +78,15 @@ class JobBuilderSpec extends AbstractJobSpec {
             triggers.'com.cloudbees.jenkins.gitHubPushTrigger'.spec.text() == ''
             triggers.'hudson.triggers.TimerTrigger'.spec.text() == 'test-cron'
             triggers.'org.jenkinsci.plugins.urltrigger.URLTrigger'.spec.text().contains('H * * * *')
-            triggers.'org.jenkinsci.plugins.urltrigger.URLTrigger'.entries.'org.jenkinsci.plugins.urltrigger.URLTriggerEntry' [0].
+            triggers.'org.jenkinsci.plugins.urltrigger.URLTrigger'.entries.'org.jenkinsci.plugins.urltrigger.URLTriggerEntry'[0].
                     url.text().contains('https://api.bintray.com/packages/hmrc/release-candidates/test/')
-            triggers.'org.jenkinsci.plugins.urltrigger.URLTrigger'.entries.'org.jenkinsci.plugins.urltrigger.URLTriggerEntry' [0].contentTypes.
-            'org.jenkinsci.plugins.urltrigger.content.JSONContentType'.jsonPaths.'org.jenkinsci.plugins.urltrigger.content.JSONContentEntry'.
+            triggers.'org.jenkinsci.plugins.urltrigger.URLTrigger'.entries.'org.jenkinsci.plugins.urltrigger.URLTriggerEntry'[0].contentTypes.
+                    'org.jenkinsci.plugins.urltrigger.content.JSONContentType'.jsonPaths.'org.jenkinsci.plugins.urltrigger.content.JSONContentEntry'.
                     jsonPath.text().contains('latest_version')
-            triggers.'org.jenkinsci.plugins.urltrigger.URLTrigger'.entries.'org.jenkinsci.plugins.urltrigger.URLTriggerEntry' [1].
+            triggers.'org.jenkinsci.plugins.urltrigger.URLTrigger'.entries.'org.jenkinsci.plugins.urltrigger.URLTriggerEntry'[1].
                     url.text().contains('https://api.bintray.com/packages/hmrc/release-candidates/test-frontend/')
-            triggers.'org.jenkinsci.plugins.urltrigger.URLTrigger'.entries.'org.jenkinsci.plugins.urltrigger.URLTriggerEntry' [1].contentTypes.
-            'org.jenkinsci.plugins.urltrigger.content.JSONContentType'.jsonPaths.'org.jenkinsci.plugins.urltrigger.content.JSONContentEntry'.
+            triggers.'org.jenkinsci.plugins.urltrigger.URLTrigger'.entries.'org.jenkinsci.plugins.urltrigger.URLTriggerEntry'[1].contentTypes.
+                    'org.jenkinsci.plugins.urltrigger.content.JSONContentType'.jsonPaths.'org.jenkinsci.plugins.urltrigger.content.JSONContentEntry'.
                     jsonPath.text().contains('latest_version')
             buildWrappers.'hudson.plugins.ansicolor.AnsiColorBuildWrapper'.colorMapName.text() == 'xterm'
             buildWrappers.'org-jenkinsci-plugins-builduser-BuildUser'.value.text() == ''
@@ -96,19 +95,52 @@ class JobBuilderSpec extends AbstractJobSpec {
             buildWrappers.'EnvInjectBuildWrapper'.info.propertiesContent.text().contains('ENV_KEY=ENV_VALUE') == true
             buildWrappers.'EnvInjectBuildWrapper'.info.scriptContent.text().contains("mkdir -p \${TMP}") == true
             buildWrappers.'EnvInjectBuildWrapper'.info.groovyScriptContent.text().contains("println \"Hello\"") == true
-            buildWrappers.'org.jenkinsci.plugins.preSCMbuildstep.PreSCMBuildStepsWrapper'.buildSteps.'hudson.tasks.Shell' [0].command.text().contains('echo prescm')
-            builders.'hudson.tasks.Shell' [0].command.text().contains('test-shell1')
-            builders.'hudson.tasks.Shell' [1].command.text().contains('ls test')
-            builders.'hudson.tasks.Shell' [1].command.text().contains('mkdir -p /tmp')
-            builders.'hudson.tasks.Shell' [1].command.text().contains('sbt clean test -Djava.io.tmpdir=/tmp')
-            builders.'hudson.tasks.Shell' [1].command.text().contains('sbt dist publish -Djava.io.tmpdir=/tmp')
+            buildWrappers.'org.jenkinsci.plugins.preSCMbuildstep.PreSCMBuildStepsWrapper'.buildSteps.'hudson.tasks.Shell'[0].command.text().contains('echo prescm')
+            builders.'hudson.tasks.Shell'[0].command.text().contains('test-shell1')
+            builders.'hudson.tasks.Shell'[1].command.text().contains('ls test')
+            builders.'hudson.tasks.Shell'[1].command.text().contains('mkdir -p /tmp')
+            builders.'hudson.tasks.Shell'[1].command.text().contains('sbt clean test -Djava.io.tmpdir=/tmp')
+            builders.'hudson.tasks.Shell'[1].command.text().contains('sbt dist publish -Djava.io.tmpdir=/tmp')
             publishers.'hudson.plugins.claim.ClaimPublisher'.text() == ''
             publishers.'hudson.tasks.junit.JUnitResultArchiver'.testResults.text() == 'test-junit'
             publishers.'htmlpublisher.HtmlPublisher'.reportTargets.'htmlpublisher.HtmlPublisherTarget'.reportDir[0].text() == 'target/test-reports/html-report'
             publishers.'htmlpublisher.HtmlPublisher'.reportTargets.'htmlpublisher.HtmlPublisherTarget'.reportName[0].text() == 'HTML Report'
             publishers.'hudson.tasks.ArtifactArchiver'.artifacts.text() == 'test-artifacts'
-            publishers.'hudson.plugins.parameterizedtrigger.BuildTrigger'.configs.'hudson.plugins.parameterizedtrigger.BuildTriggerConfig' [0].projects.text() == 'test-jobs'
-            publishers.'hudson.plugins.parameterizedtrigger.BuildTrigger'.configs.'hudson.plugins.parameterizedtrigger.BuildTriggerConfig' [0].condition.text() == 'SUCCESS'
+            publishers.'hudson.plugins.parameterizedtrigger.BuildTrigger'.configs.'hudson.plugins.parameterizedtrigger.BuildTriggerConfig'[0].projects.text() == 'test-jobs'
+            publishers.'hudson.plugins.parameterizedtrigger.BuildTrigger'.configs.'hudson.plugins.parameterizedtrigger.BuildTriggerConfig'[0].condition.text() == 'SUCCESS'
+            publishers.'hudson.plugins.descriptionsetter.DescriptionSetterPublisher'.regexp.text() == 'test-regex'
+        }
+    }
+
+    void 'test Publishers are cleared from output'() {
+        given:
+        JobBuilder jobBuilder = new JobBuilder('test-job', 'test-job-description').
+                withPublishers(claimBrokenBuildsPublisher(),
+                        jUnitReportsPublisher('test-junit-temp'),
+                        htmlReportsPublisher(['target/test-reports/html-report': 'HTML Report'])).
+                clearPublishers().
+                withPublishers(claimBrokenBuildsPublisher(),
+                        jUnitReportsPublisher('test-junit'),
+                        artifactsPublisher('test-artifacts'),
+                        jobsTriggerPublisher('test-jobs'),
+                        buildDescriptionByRegexPublisher('test-regex'))
+        when:
+        Job job = jobBuilder.build(JOB_PARENT)
+
+        then:
+        job.name == 'test-job'
+
+        println(job.node)
+
+        with(job.node) {
+            name() == 'project'
+            description.text() == 'test-job-description'
+            publishers.'hudson.plugins.claim.ClaimPublisher'.text() == ''
+            publishers.'hudson.tasks.junit.JUnitResultArchiver'.testResults.text() == 'test-junit'
+            publishers.'htmlpublisher.HtmlPublisher'.isEmpty() == true
+            publishers.'hudson.tasks.ArtifactArchiver'.artifacts.text() == 'test-artifacts'
+            publishers.'hudson.plugins.parameterizedtrigger.BuildTrigger'.configs.'hudson.plugins.parameterizedtrigger.BuildTriggerConfig'[0].projects.text() == 'test-jobs'
+            publishers.'hudson.plugins.parameterizedtrigger.BuildTrigger'.configs.'hudson.plugins.parameterizedtrigger.BuildTriggerConfig'[0].condition.text() == 'SUCCESS'
             publishers.'hudson.plugins.descriptionsetter.DescriptionSetterPublisher'.regexp.text() == 'test-regex'
         }
     }
@@ -116,7 +148,7 @@ class JobBuilderSpec extends AbstractJobSpec {
     void 'test scm clone options'() {
         given:
         JobBuilder jobBuilder = new JobBuilder('test-job', 'test-job-description').
-                                               withScm(gitHubComScm('example/example-repo', 'test-credentials', 'master', 10))
+                withScm(gitHubComScm('example/example-repo', 'test-credentials', 'master', 10))
 
         when:
         Job job = jobBuilder.build(JOB_PARENT)


### PR DESCRIPTION
This enables us to remove default publishers that are not required from default builders (e.g. ZapTestsJobBuilder).

Currently adding additional publishers doesn't overwrite the existing list, it's just additive, so a configuration like this:

```
new ZapTestsJobBuilder(TEAM, "bank-account-verification-zap-tests", "bank-account-verification-acceptance-tests")      
        .withPublishers(
                htmlReportsPublisher(['target/test-reports/html-report': 'HTML Report']),
                htmlReportsPublisher(['target/zap-reports': 'ZAP Report'], true, true)
        )
        .build(this as DslFactory)
```

Will not replace the the default publishers that come with ZapTestsJobBuilder, it will just add to them.  

This PR will allow us to add a `.clearPublishers()` to the above, before the `.withPublishers()` definition, to reset the initial publishers definition and replace them with our desired ones.

I did think about modifying the `.withPublishers()` functionality, but it may well have unintended consequences so this seemed like the safest option.