### PR TITLE
PBD-2183 Deprecate existing implementation of AwsCodeBuildStep

### DIFF
--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/AwsCodeBuildStep.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/step/AwsCodeBuildStep.groovy
@@ -4,6 +4,7 @@ import groovy.transform.builder.Builder
 import groovy.transform.builder.ExternalStrategy
 import uk.gov.hmrc.jenkinsjobbuilders.domain.configure.Configure
 
+@Deprecated
 final class AwsCodeBuildStep implements Configure {
 
     String credentialsType


### PR DESCRIPTION
This shouldn't really have been implemented as a `Configure`, as it means it doesn't play nicely with other `Step` classes in terms of ordering.

There is also a problem with the triggering failing if a sleep isn't included.

In future this might be re-implemented as a `Step`, but for now the advice is to manually define it in DSL as follows:

```
steps {awsCodeBuild projectName: 'foo-codebuild-project', ... }
```