### PR TITLE
PSEC-1325 Refactor postBuildScriptPublisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ The [open HMRC Jenkins jobs](https://github.com/hmrc/jenkins-jobs) are one examp
 
 ## Release Notes
 
-* 11.42.0 (03/08/2021) - Dont add envInject properties if they are defined with a null value
+* 12.0.0 (23/09/2021) - Support multiple build results in postBuildScriptPublisher
+* 11.42.0 (03/08/2021) - Don't add envInject properties if they are defined with a null value
 * 11.41.0 (02/08/2021) - Updated DSL property name in InjectEnvironmentJobProperty
 * 11.40.1 (02/08/2021) - Updated DSL property name in InjectEnvironmentJobProperty
 * 11.40.0 (02/08/2021) - Add the InjectEnvironmentJobProperty class to perform pre-scm environment injection
@@ -71,7 +72,7 @@ The [open HMRC Jenkins jobs](https://github.com/hmrc/jenkins-jobs) are one examp
 * 11.18.0 (19/10/2018) - Add the UpstreamTrigger class to enable building a job based on the successful completion of upstream jobs
 * 11.17.0 (09/10/2018) - Add the GitHubPullRequestTrigger class and extend the GitHubScm class to allow refspec and name to be specified.
 * 11.14.0 (24/08/2018) - Merged SecretText and SecretUsernamPassword wrapper together
-* 11.13.0 (24/08/2018) - Added abilitiy to recurse through sub folders in views
+* 11.13.0 (24/08/2018) - Added ability to recurse through sub folders in views
 * 11.12.0 (24/08/2018) - Modify cucumber reporter to use target/cucumber.json file
 * 11.11.0 (10/08/2018) - Support regex job filter in view builder.
 * 11.10.0 (03/08/2018) - Support inheritance strategies in Folders.

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     testPlugins 'org.jenkins-ci.plugins:cloudbees-folder:6.4'
     testPlugins 'org.jenkins-ci.plugins:token-macro:2.5'
     testPlugins 'org.jenkins-ci.plugins:ghprb:1.42.0'
+    testPlugins 'org.jenkins-ci.plugins:postbuildscript:2.9.1'
 }
 
 version = getReleaseVersion()

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/publisher/PostBuildScriptPublisher.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/publisher/PostBuildScriptPublisher.groovy
@@ -1,28 +1,45 @@
 package uk.gov.hmrc.jenkinsjobbuilders.domain.publisher
 
+import javaposse.jobdsl.dsl.DslFactory
+import uk.gov.hmrc.jenkinsjobbuilders.domain.publisher.Publisher
+
 final class PostBuildScriptPublisher implements Publisher {
-    private final Boolean triggerOnFailure
+    private final ArrayList<Result> results
     private final String script
 
-    private PostBuildScriptPublisher(String script, String triggerOnFailure = true) {
+    private PostBuildScriptPublisher(String script, ArrayList<Result> results) {
         this.script = script
-        this.triggerOnFailure = triggerOnFailure
+        this.results = results
     }
 
-    static PostBuildScriptPublisher postBuildScriptPublisher(String script, String triggerOnFailure = true) {
-        new PostBuildScriptPublisher(script, triggerOnFailure)
+    static PostBuildScriptPublisher postBuildScriptPublisher(String script, ArrayList<Result> results) {
+        new PostBuildScriptPublisher(script, results)
     }
 
     @Override
     Closure toDsl() {
         return {
-            postBuildScripts {
-                steps {
-                    shell(script)
+            postBuildScript {
+                buildSteps {
+                    postBuildStep {
+                        results(results*.name())
+                        buildSteps {
+                            shell {
+                                command(script)
+                            }
+                        }
+                    }
                 }
-                onlyIfBuildSucceeds(!triggerOnFailure)
-                onlyIfBuildFails(triggerOnFailure)
+                markBuildUnstable(false)
             }
         }
     }
+}
+
+enum Result {
+    SUCCESS,
+    UNSTABLE,
+    FAILURE,
+    NOT_BUILT,
+    ABORTED
 }

--- a/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/publisher/PostBuildScriptPublisherSpec.groovy
+++ b/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/publisher/PostBuildScriptPublisherSpec.groovy
@@ -3,15 +3,19 @@ package uk.gov.hmrc.jenkinsjobbuilders.domain.publisher
 import javaposse.jobdsl.dsl.Job
 import uk.gov.hmrc.jenkinsjobbuilders.domain.AbstractJobSpec
 import uk.gov.hmrc.jenkinsjobbuilders.domain.builder.JobBuilder
+import uk.gov.hmrc.jenkinsjobbuilders.domain.publisher.Result
 
 import static uk.gov.hmrc.jenkinsjobbuilders.domain.publisher.PostBuildScriptPublisher.postBuildScriptPublisher
 
 class PostBuildScriptPublisherSpec extends AbstractJobSpec {
 
-    void 'test XML output'() {
+    void 'test XML output with empty build stage result is still valid but it never runs'() {
         given:
-        JobBuilder jobBuilder = new JobBuilder('test-job', 'test-job-description').
-                                               withPublishers(postBuildScriptPublisher('test-script'))
+        JobBuilder jobBuilder = new JobBuilder('test-job', 'test-job-description')
+            .withPublishers(postBuildScriptPublisher(
+                'test-script',
+                []
+            ))
 
         when:
         Job job = jobBuilder.build(JOB_PARENT)
@@ -19,10 +23,53 @@ class PostBuildScriptPublisherSpec extends AbstractJobSpec {
         then:
         with(job.node) {
             def postBuildScript = publishers.'org.jenkinsci.plugins.postbuildscript.PostBuildScript'
-            postBuildScript.scriptOnlyIfSuccess.text() == 'false'
-            postBuildScript.scriptOnlyIfFailure.text() == 'true'
-            postBuildScript.markBuildUnstable.text() == 'false'
-            postBuildScript.buildSteps.'hudson.tasks.Shell'.command.text() == 'test-script'
+            postBuildScript.config.markBuildUnstable.text() == 'false'
+            def postBuildStep = postBuildScript.config.buildSteps.'org.jenkinsci.plugins.postbuildscript.model.PostBuildStep'
+            postBuildStep.buildSteps.'hudson.tasks.Shell'.command.text() == 'test-script'
+            postBuildStep.results.text() == ''
+        }
+    }
+
+    void 'test XML output with one build stage result'() {
+        given:
+        JobBuilder jobBuilder = new JobBuilder('test-job', 'test-job-description')
+            .withPublishers(postBuildScriptPublisher(
+                'test-script',
+                [Result.SUCCESS]
+            ))
+
+        when:
+        Job job = jobBuilder.build(JOB_PARENT)
+
+        then:
+        with(job.node) {
+            def postBuildScript = publishers.'org.jenkinsci.plugins.postbuildscript.PostBuildScript'
+            postBuildScript.config.markBuildUnstable.text() == 'false'
+            def postBuildStep = postBuildScript.config.buildSteps.'org.jenkinsci.plugins.postbuildscript.model.PostBuildStep'
+            postBuildStep.buildSteps.'hudson.tasks.Shell'.command.text() == 'test-script'
+            postBuildStep.results.string[0].text() == 'SUCCESS'
+        }
+    }
+
+    void 'test XML output with two build stage results'() {
+        given:
+        JobBuilder jobBuilder = new JobBuilder('test-job', 'test-job-description')
+            .withPublishers(postBuildScriptPublisher(
+                'test-script',
+                [Result.SUCCESS,Result.UNSTABLE]
+            ))
+
+        when:
+        Job job = jobBuilder.build(JOB_PARENT)
+
+        then:
+        with(job.node) {
+            def postBuildScript = publishers.'org.jenkinsci.plugins.postbuildscript.PostBuildScript'
+            postBuildScript.config.markBuildUnstable.text() == 'false'
+            def postBuildStep = postBuildScript.config.buildSteps.'org.jenkinsci.plugins.postbuildscript.model.PostBuildStep'
+            postBuildStep.buildSteps.'hudson.tasks.Shell'.command.text() == 'test-script'
+            postBuildStep.results.string[0].text() == 'SUCCESS'
+            postBuildStep.results.string[1].text() == 'UNSTABLE'
         }
     }
 }


### PR DESCRIPTION
- remove confusing boolean - string use for a build result
- add ability to pass more than result (as when script should run)
- use enum for build result to avoid typos