### PR TITLE
PBD-3394 Remove deprecated properties for cucumber and xvfb plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The [open HMRC Jenkins jobs](https://github.com/hmrc/jenkins-jobs) are one examp
 
 ## Release Notes
 
+* 13.1.0 (19/11/2021) - Remove deprecated properties from cucumber and xvfb plugins
 * 13.0.0 (28/10/2021) - Only support Post Build Script plugin version 3.0.0 and higher
 * 12.0.0 (23/09/2021) - Support multiple build results in postBuildScriptPublisher
 * 11.42.0 (03/08/2021) - Don't add envInject properties if they are defined with a null value

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/configure/CucumberReportsPublisher.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/configure/CucumberReportsPublisher.groovy
@@ -29,11 +29,6 @@ final class CucumberReportsPublisher implements Configure {
                 'jsonReportDirectory'(jsonReportDirectory)
                 'fileIncludePattern'(fileIncludePattern)
                 'fileExcludePattern'(fileExcludePattern)
-                'pluginUrlPath'('')
-                'skippedFails'('false')
-                'undefinedFails'('false')
-                'noFlashCharts'('false')
-                'ignoreFailedTests'('false')
                 'buildStatus'('FAILURE')
             }
         }

--- a/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/configure/XvfbBuildWrapper.groovy
+++ b/src/main/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/configure/XvfbBuildWrapper.groovy
@@ -11,7 +11,6 @@ final class XvfbBuildWrapper implements Configure {
     Closure toDsl() {
         return {
             it / 'buildWrappers' / 'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper' {
-                'switch'('on')
                 'installationName'('default')
                 'screen'('1920x1080x24')
                 'displayNameOffset'('1')

--- a/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/configure/XvfbBuildWrapperSpec.groovy
+++ b/src/test/groovy/uk/gov/hmrc/jenkinsjobbuilders/domain/configure/XvfbBuildWrapperSpec.groovy
@@ -21,7 +21,6 @@ class XvfbBuildWrapperSpec extends AbstractJobSpec {
 
         then:
         with(job.node) {
-            buildWrappers.'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper'.switch.text() == 'on'
             buildWrappers.'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper'.parallelBuild.text() == 'false'
             buildWrappers.'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper'.displayName.isEmpty()
             buildWrappers.'org.jenkinsci.plugins.xvfb.XvfbBuildWrapper'.displayNameOffset.text() == '1'


### PR DESCRIPTION
More modern versions of these plugins no longer include these properties. Referencing them was causing xstream to generate huge stack traces when processing the DSL.