### PR TITLE
PBD-4733 Upgrade JFrog plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.jfrog.artifactory" version "4.8.1"
+    id "com.jfrog.artifactory" version "4.33.1"
 }
 
 apply plugin: 'groovy'


### PR DESCRIPTION
jenkins-job-builders-hmrc-release Jenkins failing due to it looking like the files for the current plugin version are no long avalible.